### PR TITLE
Kd/fix allow svg  doctype

### DIFF
--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -35,8 +35,8 @@ const sniffLen = 512
 // SVGMimeType MIME type of SVG images.
 const SVGMimeType = "image/svg+xml"
 
-var svgTagRegex = regexp.MustCompile(`(?si)\A\s*(?:<!--.*?-->\s*)*<svg[\s>]`)
-var svgTagInXMLRegex = regexp.MustCompile(`(?si)\A<\?xml\b.*?\?>\s*(?:<!--.*?-->\s*)*<svg[\s>]`)
+var svgTagRegex = regexp.MustCompile(`(?si)\A\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg[\s:]+.*?>)\s*)*<svg[\s>]`)
+var svgTagInXMLRegex = regexp.MustCompile(`(?si)\A<\?xml\b.*?\?>\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg[\s:]+.*?>)\s*)*<svg[\s>]`)
 
 // EncodeMD5 encodes string to md5 hex value.
 func EncodeMD5(str string) string {

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -35,8 +35,8 @@ const sniffLen = 512
 // SVGMimeType MIME type of SVG images.
 const SVGMimeType = "image/svg+xml"
 
-var svgTagRegex = regexp.MustCompile(`(?s)\A\s*(?:<!--.*?-->\s*)*<svg\b`)
-var svgTagInXMLRegex = regexp.MustCompile(`(?s)\A<\?xml\b.*?\?>\s*(?:<!--.*?-->\s*)*<svg\b`)
+var svgTagRegex = regexp.MustCompile(`(?si)\A\s*(?:<!--.*?-->\s*)*<svg[\s>]`)
+var svgTagInXMLRegex = regexp.MustCompile(`(?si)\A<\?xml\b.*?\?>\s*(?:<!--.*?-->\s*)*<svg[\s>]`)
 
 // EncodeMD5 encodes string to md5 hex value.
 func EncodeMD5(str string) string {

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -35,8 +35,8 @@ const sniffLen = 512
 // SVGMimeType MIME type of SVG images.
 const SVGMimeType = "image/svg+xml"
 
-var svgTagRegex = regexp.MustCompile(`(?si)\A\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg[\s:]+.*?>)\s*)*<svg[\s>]`)
-var svgTagInXMLRegex = regexp.MustCompile(`(?si)\A<\?xml\b.*?\?>\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg[\s:]+.*?>)\s*)*<svg[\s>]`)
+var svgTagRegex = regexp.MustCompile(`(?si)\A\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg([\s:]+.*?>|>))\s*)*<svg[\s>]`)
+var svgTagInXMLRegex = regexp.MustCompile(`(?si)\A<\?xml\b.*?\?>\s*(?:(<!--.*?-->|<!DOCTYPE\s+svg([\s:]+.*?>|>))\s*)*<svg[\s>]`)
 
 // EncodeMD5 encodes string to md5 hex value.
 func EncodeMD5(str string) string {

--- a/modules/base/tool_test.go
+++ b/modules/base/tool_test.go
@@ -216,6 +216,9 @@ func TestIsSVGImageFile(t *testing.T) {
 	assert.True(t, IsSVGImageFile([]byte(`<!-- Multiline
 	Comment -->
 	<svg></svg>`)))
+	assert.True(t, IsSVGImageFile([]byte(`<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Basic//EN"
+	"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-basic.dtd">
+	<svg></svg>`)))
 	assert.True(t, IsSVGImageFile([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 	<!-- Comment -->
 	<svg></svg>`)))
@@ -224,6 +227,11 @@ func TestIsSVGImageFile(t *testing.T) {
 	<!-- Comments -->
 	<svg></svg>`)))
 	assert.True(t, IsSVGImageFile([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	<!-- Multline
+	Comment -->
+	<svg></svg>`)))
+	assert.True(t, IsSVGImageFile([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 	<!-- Multline
 	Comment -->
 	<svg></svg>`)))


### PR DESCRIPTION
- Uses `<svg[\s>]` instead of `<svg\b` to make sure we won't capture non-svg elements
- Uses case-insensitive regex
- Adds a filter to optionally allow doctype declarations for svg only (even though MDN recommends against doctypes for svg they are still commonly used)